### PR TITLE
Fix code highlighing for included pom/gradle files

### DIFF
--- a/_includes/widget_templates.html
+++ b/_includes/widget_templates.html
@@ -68,29 +68,36 @@
 
 {%if maven_pom_template contains 'not found in _includes directory' %}
 {% capture maven_pom_template %}
-<span class="nt">&lt;dependencies&gt;</span>
-    <span class="nt">&lt;dependency&gt;</span>
-        <span class="nt">&lt;groupId&gt;</span>{@= groupId @}<span class="nt">&lt;/groupId&gt;</span>
-        <span class="nt">&lt;artifactId&gt;</span>{@= artifactId @}<span class="nt">&lt;/artifactId&gt;</span>
-        <span class="nt">&lt;version&gt;</span>{@= version @}<span class="nt">&lt;/version&gt;</span>
-    <span class="nt">&lt;/dependency&gt;</span>
-<span class="nt">&lt;/dependencies&gt;</span>
-{@ if (repository) { @}
-<span class="nt">&lt;repositories&gt;</span>
-    <span class="nt">&lt;repository&gt;</span>
-        <span class="nt">&lt;id&gt;</span>{@= repository.id @}<span class="nt">&lt;/id&gt;</span>
-        <span class="nt">&lt;name&gt;</span>{@= repository.name @}<span class="nt">&lt;/name&gt;</span>
-        <span class="nt">&lt;url&gt;</span>{@= repository.url @}<span class="nt">&lt;/url&gt;</span>
-        <span class="nt">&lt;snapshots&gt;</span>
-            <span class="nt">&lt;enabled&gt;</span>{@= repository.snapshotsEnabled @}<span class="nt">&lt;/enabled&gt;</span>
-        <span class="nt">&lt;/snapshots&gt;</span>
-    <span class="nt">&lt;/repository&gt;</span>
-<span class="nt">&lt;/repositories&gt;</span>
-{@ } @}
+<dependencies>
+    <dependency>
+        <groupId>{@= groupId @}</groupId>
+        <artifactId>{@= artifactId @}</artifactId>
+        <version>{@= version @}</version>
+    </dependency>
+</dependencies>
 {% endcapture %}
 {% endif %}
 
-<script type="text/html" id="project-download-maven-widget-template">{{ maven_pom_template }}</script>
+<script type="text/html" id="project-download-maven-widget-template">
+{% highlight xml %}
+{{ maven_pom_template }}
+{% endhighlight %}
+</script>
+
+<script type="text/html" id="project-repository-maven-widget-template">
+{% highlight xml %}
+<repositories>
+    <repository>
+        <id>{@= repository.id @}</id>
+        <name>{@= repository.name @}</name>
+        <url>{@= repository.url @}</url>
+        <snapshots>
+            <enabled>{@= repository.snapshotsEnabled @}</enabled>
+        </snapshots>
+    </repository>
+</repositories>
+{% endhighlight %}
+</script>
 
 {% capture gradle_template %}
 {% include build.gradle %}
@@ -98,20 +105,27 @@
 
 {%if gradle_template contains 'not found in _includes directory' %}
 {% capture gradle_template %}
-<span class="n">dependencies&nbsp;</span><span class="o">{</span>
-    <span class="n">compile&nbsp;</span><span class="s1">'{@= groupId @}:{@= artifactId @}:{@= version @}'</span>
-<span class="o">}</span>
-{@ if (repository) { @}
-<span class="n">repositories&nbsp;</span><span class="o">{</span>
-    <span class="n">maven&nbsp;</span><span class="o">{</span>
-        <span class="n">url&nbsp;</span><span class="s1">'{@= repository.url @}'</span>
-    <span class="o">}</span>
-<span class="o">}</span>
-{@ } @}
+dependencies {
+    compile '{@= groupId @}:{@= artifactId @}:{@= version @}'
+}
 {% endcapture %}
 {% endif %}
 
-<script type="text/html" id="project-download-gradle-widget-template">{{ gradle_template }}</script>
+<script type="text/html" id="project-download-gradle-widget-template">
+{% highlight groovy %}
+{{ gradle_template }}
+{% endhighlight %}
+</script>
+
+<script type="text/html" id="project-repository-gradle-widget-template">
+{% highlight groovy %}
+repositories {
+    maven {
+        url '{@= repository.url @}'
+    }
+}
+{% endhighlight %}
+</script>
 
 <script type="text/html" id="project-download-zip-widget-template">
 This is a zip url

--- a/js/projectDocumentationWidget.js
+++ b/js/projectDocumentationWidget.js
@@ -90,8 +90,14 @@ Spring.DocumentationWidgetView = Backbone.View.extend({
 Spring.SnippetView = Backbone.View.extend({
   initialize: function () {
     var snippetType = this.options.snippetType;
-    this.combinedTemplate = _.template($("#project-download-" + snippetType + "-widget-template").text());
-
+    var downloadTemplate = $(document.createElement('div')).html($("#project-download-" + snippetType + "-widget-template").text());
+    var repositoryTemplate = $(document.createElement('div')).html($("#project-repository-" + snippetType + "-widget-template").text());
+    this.combinedTemplate = _.template(
+        downloadTemplate.find("code:first").html() +
+        "{@ if (repository) { @}" +
+        repositoryTemplate.find("code:first").html() +
+        "{@ } @}"
+    );
     _.bindAll(this, "render");
   },
 


### PR DESCRIPTION
Replace the highlighting logic used for maven and gradle snippets with
Jekyll code snippet highlighting (`{% highlight %}`). This change both
simplifies `widget_templates.html` and allows external pom/gradle
includes to be highlighted.

The change also splits `widget-template` into two distinct elements,
one for the dependencies and one for repositories. This is necessary
due to the fact the the `{@ @}` condition statements used by
`underscore.js` are incorrectly highlighted as errors when parsing
`gradle` snippets (preventing them from being recognized). Splitting the
repository template has the additional benefit of custom pom/gradle
files no longer need to specify a repository section.

[Finishes: #55617424]
