### PR TITLE
Make the link to a project's forum optional

### DIFF
--- a/_includes/billboard.html
+++ b/_includes/billboard.html
@@ -17,10 +17,12 @@
                             <a href="{{ site.github_repo_url }}" class="project-link">
                                 <i class="icon-github"></i>
                             </a>
+{% if site.forum %}
                             <a href="{{ site.forum }}" class="project-link project-link-forum">
                                 <div class="spring-icon spring-icon-forum">
                                 </div>
                             </a>
+{% endif %}
                         </div>
                     </div>
 


### PR DESCRIPTION
Omit the link to the forum if the project's metadata does not provide a forum url
