### PR TITLE
Fix "rm -rf" instruictions

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -15,8 +15,7 @@ From within your Spring project's git checkout directory:
 
 ### Remove all files
 
-    git rm -rf *
-    git rm -rf '.*'
+    git rm -rf `git ls-files` && rm -rf *
 
 ### Add the gh-pages-upstream remote
 


### PR DESCRIPTION
Existing copy is wrong because "git rm -rf *" fails if there are any untracked files (e.g. target/). Changed to "git rm -rf `git ls-files`".
